### PR TITLE
Fix timestamp checks

### DIFF
--- a/.assertions/get_target_info.sh
+++ b/.assertions/get_target_info.sh
@@ -57,25 +57,10 @@ if [ "$TARGET" != "$CURRENT_TARGET" ]; then
 		fi
 	}
 
-	export_target_build_is_outdated() {
-		if [ ! -f "$TARGET_BINARY_PATH" ]; then
-			export TARGET_BUILD_IS_OUTDATED=true
-		else
-			TARGET_SOURCE_MODIFICATION_TIME=$(stat -c %Y "$TARGET_SOURCE_PATH")
-			TARGET_BINARY_MODIFICATION_TIME=$(stat -c %Y "$TARGET_BINARY_PATH")
-			if [ "$TARGET_SOURCE_MODIFICATION_TIME" -gt "$TARGET_BINARY_MODIFICATION_TIME" ]; then
-				export TARGET_BUILD_IS_OUTDATED=true
-			else
-				export TARGET_BUILD_IS_OUTDATED=""
-			fi
-		fi
-	}
-
 	export_target_rule
 	export_target_is_test
 	export_target_source_path
 	export_target_binary_path
-	export_target_build_is_outdated
 
 	export CURRENT_TARGET=$TARGET
 fi

--- a/build.sh
+++ b/build.sh
@@ -81,9 +81,7 @@ elif [ "$ACTION" == "target" ]; then
 	do
 		export TARGET=$TARGET
 		source "$PROJECT_ROOT/.assertions/get_target_info.sh"
-		if [ $TARGET_BUILD_IS_OUTDATED ]; then
-			make $TARGET_RULE
-		fi
+		make $TARGET_RULE
 	done
 else
 	echo "Error: unknown action $ACTION"

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -41,6 +41,7 @@ if [ "$1" == "--help" ]; then
 elif [ "$1" == "add" ]; then
 	shift
 	source "$PROJECT_ROOT/.assertions/dependency_manager/add.sh"
+	touch "$DEPENDENCY_MANAGER_DIR"
 elif [ "$1" == "remove" ]; then
 	shift
 	source "$PROJECT_ROOT/.assertions/dependency_manager/remove.sh"
@@ -67,6 +68,7 @@ elif [ "$1" == "install" ]; then
 	else
 		cd "$DEPENDENCY_MANAGER_DIR/modules"
 		source "$DEPENDENCY_MANAGER_DIR/install.sh"
+		touch "$DEPENDENCY_MANAGER_DIR"
 	fi
 else
 	echo "Error: unknown action '$1'"


### PR DESCRIPTION
Some scripts were not ensuring the one command policy because the timestamp checking was broken. This was fixed by:

* Executing "touch external_dependencies" whenever a dependency is installed;
* Changing build script to always run _make_ instead of badly reimplementing make's status check;