### PR TITLE
Added post download script to git module

### DIFF
--- a/.assertions/dependency_manager/modules/git/add_help.txt
+++ b/.assertions/dependency_manager/modules/git/add_help.txt
@@ -1,12 +1,14 @@
 Help:
 Add dependency on source files of projects stored in git repositories. Branch 'master' is always the one used during installation
 
-Usage: ./dependencies.sh add git GIT_URL [GIT_COMMIT] [LOCAL_ONLY] [OBJS_DIR] [INCLUDE_DIR]
+Usage: ./dependencies.sh add git GIT_URL [GIT_COMMIT] [LOCAL_ONLY] [OBJS_DIR] [INCLUDE_DIR] [POST_DOWNLOAD_SCRIPT]
 
-LOCAL_ONLY: boolean value which tells whether this dependency has to be installed recursively when adding this project as a dependency in another one. Default is false
 GIT_URL: HTTP URL used to clone git repositories. SSH URLs are not acceptable, since SSH may not be configured in every developer environment
 GIT_COMMIT: git commit to use. May be a git tag. The lastest tagged commit will be used by default.
 	IMPORTANT: the commit will be frozen, meaning all dependency installations will always use the same version. This is true even if the commit is not specified
+LOCAL_ONLY: boolean value which tells whether this dependency has to be installed recursively when adding this project as a dependency in another one. Default is false
 OBJS_DIR: path relative to the project root where the .cpp source files are located. "src/objs" is the default
 INCLUDE_DIR: path relative to the project root where the header files are located. "src/objs" is the default
+POST_DOWNLOAD_SCRIPT: a script to execute right after the checkout. The script is executed inside the dependency root and can be used to prepare it for installation. The script can be any valid bash command
+	Eg.: A dependency you want to add might have its files all over the place, so you can use a script to move all files to a centralized directory which you can then use as your OBJS_DIR
 

--- a/.assertions/dependency_manager/modules/git/install.sh
+++ b/.assertions/dependency_manager/modules/git/install.sh
@@ -27,6 +27,7 @@ GIT_COMMIT="$2"
 LOCAL_ONLY="$3"
 GIT_OBJS_DIR="$4"
 GIT_INCLUDE_DIR="$5"
+POST_DOWNLOAD_SCRIPT="$6"
 ##################### Command Line Interface ##########################
 
 GIT_URL_IS_HTTP=$(echo "$GIT_URL" | grep -oe "^http")
@@ -63,6 +64,11 @@ if [ "$CHECKOUT_STATUS" != "0" ]; then
 	echo "Error: not a valid commit: '$GIT_COMMIT'"
 	rollback_installation
 	exit 1
+fi
+
+if [ "$POST_DOWNLOAD_SCRIPT" != "" ]; then
+	echo "Info: executing post download script '$POST_DOWNLOAD_SCRIPT'" 1>&2
+	$POST_DOWNLOAD_SCRIPT
 fi
 
 if [ "$GIT_OBJS_DIR" == "" ]; then
@@ -115,5 +121,5 @@ if [ -f "$DEPENDENCY_REPOSITORY_DIR/dependencies.sh" ]; then
 	fi
 fi
 
-echo "Info: dependency configured: $GIT_URL $GIT_COMMIT $LOCAL_ONLY \"$GIT_OBJS_DIR\" \"$GIT_INCLUDE_DIR\""
+echo "Info: dependency configured: $GIT_URL $GIT_COMMIT $LOCAL_ONLY \"$GIT_OBJS_DIR\" \"$GIT_INCLUDE_DIR\" \"$POST_DOWNLOAD_SCRIPT\""
 


### PR DESCRIPTION
By having a post download script it's possible to add virtually any git project as a dependency as long as it's possible to design a script which can convert its structure to a structure the framework can understand.